### PR TITLE
Update mouse_handler_base.cpp for OS X to look for ctrl-click instead of command-click

### DIFF
--- a/src/mouse_handler_base.cpp
+++ b/src/mouse_handler_base.cpp
@@ -42,7 +42,7 @@ int commands_disabled= 0;
 static bool command_active()
 {
 #ifdef __APPLE__
-	return (SDL_GetModState()&KMOD_META) != 0;
+	return (SDL_GetModState()&KMOD_CTRL) != 0;
 #else
 	return false;
 #endif


### PR DESCRIPTION
For Apple, control is the modifier key that is used for contextual menus.

KMOD_CTRL will check for a control-click instead of a command click, which is behavior not typically ever used in OS X. This fixes [#15259](https://gna.org/bugs/?15259).

I’ve built and verified with this patch, it works correctly. Native secondary-clicking (like two-finger clicking on a trackpad) still works, and is unaffected.