### PR TITLE
Simple hot keys

### DIFF
--- a/data/core/hotkeys.cfg
+++ b/data/core/hotkeys.cfg
@@ -46,16 +46,18 @@
     # Which means "touch"
     mouse=255
 [/hotkey]
-
 [hotkey]
     command=aiformula
     key=f
 [/hotkey]
-
 [hotkey]
     command=accelerated
     key=a
     {IF_APPLE_CMD_ELSE_CTRL}
+[/hotkey]
+[hotkey]
+    command=bestenemymoves
+    key=b
 [/hotkey]
 [hotkey]
     command=bestenemymoves
@@ -65,7 +67,15 @@
 [hotkey]
     command=changeside
     key=u
+[/hotkey]
+[hotkey]
+    command=changeside
+    key=u
     shift=yes
+[/hotkey]
+[hotkey]
+    command=chatlog
+    key=l
 [/hotkey]
 [hotkey]
     command=chatlog
@@ -93,11 +103,19 @@
 [/hotkey]
 [hotkey]
     command=continue
-    key=t
+    key=c
 [/hotkey]
 [hotkey]
     command=cycle
     key=n
+[/hotkey]
+[hotkey]
+    command=cycle
+    key="return"
+[/hotkey]
+[hotkey]
+    command=cycleback
+    key=p
 [/hotkey]
 [hotkey]
     command=cycleback
@@ -107,6 +125,10 @@
 [hotkey]
     command=describeunit
     key=d
+[/hotkey]
+[hotkey]
+    command=describeterrain
+    key=i
 [/hotkey]
 [hotkey]
     command=describeterrain
@@ -127,6 +149,11 @@
 #endif
 [/hotkey]
 [hotkey]
+    command=endturn
+    key="return"
+    alt=yes
+[/hotkey]
+[hotkey]
     command=fullscreen
     key=f
     {IF_APPLE_CMD_ELSE_CTRL}
@@ -137,13 +164,26 @@
 [/hotkey]
 [hotkey]
     command=holdposition
+    key=h
+[/hotkey]
+[hotkey]
+    command=holdposition
     key="space"
     shift=yes
 [/hotkey]
 [hotkey]
     command=killunit
+    key="delete"
+[/hotkey]
+[hotkey]
+    command=killunit
     key=k
     shift=yes
+[/hotkey]
+[hotkey]
+    command=killunit
+    key="backspace"
+    {IF_APPLE_CMD_ELSE_CTRL}
 [/hotkey]
 [hotkey]
     command=labelteamterrain
@@ -157,7 +197,7 @@
 [/hotkey]
 [hotkey]
     command=leader
-    key=l
+    key=k
 [/hotkey]
 [hotkey]
     command=load
@@ -169,6 +209,10 @@
     key=m
     {IF_APPLE_CMD_ELSE_CTRL}
     alt=yes
+[/hotkey]
+[hotkey]
+    command=objectives
+    key=j
 [/hotkey]
 [hotkey]
     command=objectives
@@ -191,8 +235,21 @@
 [/hotkey]
 [hotkey]
     command=recall
+    key=e
+[/hotkey]
+[hotkey]
+    command=recall
+    key=e
+    {IF_APPLE_CMD_ELSE_CTRL}
+[/hotkey]
+[hotkey]
+    command=recall
     key=r
     alt=yes
+[/hotkey]
+[hotkey]
+    command=recruit
+    key=r
 [/hotkey]
 [hotkey]
     command=recruit
@@ -201,7 +258,14 @@
 [/hotkey]
 [hotkey]
     command=redo
-    key=r
+    key=z
+    shift=yes
+[/hotkey]
+[hotkey]
+    command=redo
+    key=z
+    {IF_APPLE_CMD_ELSE_CTRL}
+    shift=yes
 [/hotkey]
 [hotkey]
     command=renameunit
@@ -226,11 +290,19 @@
 [hotkey]
     command=showenemymoves
     key=v
+[/hotkey]
+[hotkey]
+    command=showenemymoves
+    key=v
     {IF_APPLE_CMD_ELSE_CTRL}
 [/hotkey]
 [hotkey]
     command=speak
     key=m
+[/hotkey]
+[hotkey]
+    command=speak
+    key="tab"
 [/hotkey]
 [hotkey]
     command=speaktoall
@@ -244,6 +316,15 @@
 [/hotkey]
 [hotkey]
     command=statistics
+    key=t
+[/hotkey]
+[hotkey]
+    command=statistics
+    key=t
+    alt=yes
+[/hotkey]
+[hotkey]
+    command=statustable
     key=s
 [/hotkey]
 [hotkey]
@@ -257,12 +338,34 @@
     {IF_APPLE_CMD_ELSE_CTRL}
 [/hotkey]
 [hotkey]
+    command=toggleellipses
+    key=.
+[/hotkey]
+[hotkey]
+    command=toggleellipses
+    key=e
+    {IF_APPLE_CMD_ELSE_CTRL}
+[/hotkey]
+[hotkey]
+    command=togglegrid
+    key=g
+[/hotkey]
+[hotkey]
     command=togglegrid
     key=g
     {IF_APPLE_CMD_ELSE_CTRL}
 [/hotkey]
 [hotkey]
     command=undo
+    key=z
+[/hotkey]
+[hotkey]
+    command=undo
+    key=z
+    {IF_APPLE_CMD_ELSE_CTRL}
+[/hotkey]
+[hotkey]
+    command=unitlist
     key=u
 [/hotkey]
 [hotkey]
@@ -284,10 +387,18 @@
     key="="
 [/hotkey]
 [hotkey]
+    command=zoomin
+    key="+"
+[/hotkey]
+[hotkey]
     command=zoomout
     key=-
 [/hotkey]
-# Disabled for 1.9 and the whiteboard beta test
+[hotkey]
+    command=zoomout
+    key=-
+    shift=yes
+[/hotkey]# Disabled for 1.9 and the whiteboard beta test
 #[hotkey]
 #    command=delayshroud
 #    key=d
@@ -296,6 +407,7 @@
 [hotkey]
     command=wbtoggle
     key=p
+    alt=yes
 [/hotkey]
 [hotkey]
     command=wbexecuteaction
@@ -308,7 +420,7 @@
 [/hotkey]
 [hotkey]
     command=wbdeleteaction
-    key=h
+    key="backspace"
 [/hotkey]
 [hotkey]
     command=wbbumpupaction
@@ -320,7 +432,7 @@
 [/hotkey]
 [hotkey]
     command=wbsupposedead
-    key=i
+    key=x
 [/hotkey]
 
 [hotkey]


### PR DESCRIPTION
Borrows heavily from https://r.wesnoth.org/t41525.

Most of the common commands now have single keystrokes on the keyboard.

The following has changed:
* Planning mode is now `ALT + P` instead of `P`
* Undo is now `Z` or `CTRL + Z` instead of `U`
* Redo is now `SHIFT + Z` or `CTRL + SHIFT + Z` instead of `R`
* Suppose Dead (Planning Mode) is now `X` instead of `I`
* Go to Leader is now `K` instead of `L`
* Delete Action (Planning Mode) is now `BACKSPACE` instead of `H`
* Continue is now `C` instead of `T`